### PR TITLE
Allow delete confirmation with a single 'y'

### DIFF
--- a/bin/fuzpad
+++ b/bin/fuzpad
@@ -162,7 +162,7 @@ delete_notes(){
 		--border-label-pos=0 \
 		--highlight-line \
 		--layout=reverse $(list_order) \
-		--disabled --prompt="Type 'yes' to confirm deletion > " \
+		--disabled --prompt="Type 'yes' or 'y' to confirm deletion > " \
 		--preview-window=down:$PREVIEW_SIZE:noinfo:wrap \
 		--preview='
 			IFS=":" read -r TITLE NOTE <<< {}
@@ -170,7 +170,7 @@ delete_notes(){
 			echo -e "\e[1m$TITLE\e[0m" | bat --color=always --theme='$BAT_THEME' --style=plain
 			sed "1{/^#!/ { n; d; }; d; }" "'$FUZPAD_DIR'/$NOTE" | bat --color=always --theme='$BAT_THEME' --style=plain' | sed -n '1p')
 
-		if [[ "$CONFIRMATION" =~ ^[Yy][Ee][Ss]$ ]]; then
+		if [[ "$CONFIRMATION" =~ ^[Yy][Ee]?[Ss]?$ ]]; then
 			for NOTE in "${NOTES[@]}"; do
 				rm "./$NOTE"	
 			done


### PR DESCRIPTION
Most programs (editors, file managers) allow delete confirmation with a single "y", because typing out the whole "yes" might be excessive.