### PR TITLE
open selected result using $FUZPAD_DIR so files open correctly on Enter

### DIFF
--- a/bin/fuzpad
+++ b/bin/fuzpad
@@ -232,7 +232,7 @@ search_notes(){
 		
 		local LAST_QUERY="$(echo "$SELECTED" | sed -n '1p')"
 		IFS=":" read -r CONTENT LINE NOTE <<< $(echo "$SELECTED" | sed -n '2p')
-		${EDITOR} +$LINE "./$NOTE"
+		${EDITOR} +$LINE "$FUZPAD_DIR/$NOTE"
 	done
 	LAST_QUERY=""
 }


### PR DESCRIPTION
**Summary**
Pressing Enter on a search result did not open the file in the editor. This PR adjusts the path used in search_notes to always reference $FUZPAD_DIR, ensuring the selected note opens at the correct line.

**Problem**
In search_notes, the editor was called with a relative path (./$NOTE). Because $NOTE is derived from basename during the grep/fzf pipeline, the path could be incorrect at runtime. Result: the editor fails to open the file when pressing Enter on a search result.

**Fix**
Replace:
${EDITOR} +$LINE "./$NOTE"


with:
${EDITOR} +$LINE "$FUZPAD_DIR/$NOTE"


**Why this works**
Using $FUZPAD_DIR/$NOTE guarantees the note path resolves inside the configured notes directory, independent of the current working directory and how $NOTE was constructed.

**Reproduction steps (before fix)**
Create multiple notes under $FUZPAD_DIR.
Launch FuzPad → Search.
Type a query and press Enter on a result.
File does not open in the editor.
Validation (after fix)
Same steps as above → file opens correctly at the matched line via ${EDITOR} +$LINE.

**Additional notes**
No behavior changes in Open/Tags menus.
Kept scope minimal; no functional refactors.
Tested with default editor (nano) and custom $EDITOR.